### PR TITLE
fix:failed to load messageList

### DIFF
--- a/src/components/Generator.tsx
+++ b/src/components/Generator.tsx
@@ -28,8 +28,8 @@ export default () => {
     })
 
     try {
-      if (sessionStorage.getItem('messageList'))
-        setMessageList(JSON.parse(sessionStorage.getItem('messageList')))
+      if (localStorage.getItem('messageList'))
+        setMessageList(JSON.parse(localStorage.getItem('messageList')))
 
       if (localStorage.getItem('stickToBottom') === 'stick')
         setStick(true)
@@ -44,7 +44,7 @@ export default () => {
   })
 
   const handleBeforeUnload = () => {
-    sessionStorage.setItem('messageList', JSON.stringify(messageList()))
+    localStorage.setItem('messageList', JSON.stringify(messageList()))
     isStick() ? localStorage.setItem('stickToBottom', 'stick') : localStorage.removeItem('stickToBottom')
   }
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!
Thank you for contributing!
Before submitting the PR, please make sure you do the following:
- Discuss first. It's always better to open a feature request issue first to discuss with the maintainers whether the feature is desired and the design of those features.
- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
-->

### Description
Failure to load historical session data(messageList) when the page is opened
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
#21 

### Additional context
Because the storage mode is sessionStorage, it is a session-level cache, which will be empty when the page is closed, so the history of the messages is empty when the page is reopened. Now I changed the storage mode to localStorage, it can be stored permanently until you delete it manually.
<!-- e.g. is there anything you'd like reviewers to focus on? -->