### PR TITLE
convert message list into parameters that conforms to the api rules(Interim Solution)

### DIFF
--- a/src/components/Generator.tsx
+++ b/src/components/Generator.tsx
@@ -73,6 +73,18 @@ export default () => {
     window.scrollTo({ top: document.body.scrollHeight, behavior: 'instant' })
   }
 
+  // ? Interim Solution
+  // ensure that the user and the model have a one-to-one conversation and avoid any errors like:
+  // "Please ensure that multiturn requests ends with a user role or a function response."
+  // convert the raw list into data that conforms to the interface api rules
+  const convertReqMsgList = (originalMsgList: ChatMessage[]) => {
+    return originalMsgList.filter((curMsg, i, arr) => {
+      // Check if there is a next message
+      const nextMsg = arr[i + 1]
+      // Include the current message if there is no next message or if the roles are different
+      return !nextMsg || curMsg.role !== nextMsg.role
+    })
+  }
   const requestWithLatestMessage = async() => {
     setLoading(true)
     setCurrentAssistantMessage('')
@@ -89,7 +101,7 @@ export default () => {
       const response = await fetch('/api/generate', {
         method: 'POST',
         body: JSON.stringify({
-          messages: requestMessageList,
+          messages: convertReqMsgList(requestMessageList),
           time: timestamp,
           pass: storagePassword,
           sign: await generateSignature({


### PR DESCRIPTION
convert message list into parameters that conforms to the api rules(Interim Solution)

ensure that the user and the model have a one-to-one conversation and avoid any errors like: "Please ensure that multiturn requests ends with a user role or a function response."

<!-- DO NOT IGNORE THE TEMPLATE!
Thank you for contributing!
Before submitting the PR, please make sure you do the following:
- Discuss first. It's always better to open a feature request issue first to discuss with the maintainers whether the feature is desired and the design of those features.
- Use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
-->

### Description
It will break the GeminiPro API rules and cause an error if there are two role attributes with the same value in a row in the message list. See the example below.:
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
<img width="669" alt="image" src="https://github.com/babaohuang/GeminiProChat/assets/58702199/6253704c-61a9-4cf9-bb31-54ff775c290f">

### Linked Issues
#28 (聊天出现“Error Please ensure that multiturn requests ends with a user role or a function response.”)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
For now, this is only a interim solution. You can ignore this pull request if the GeminiPro team officially fixes this issue, or if there is a better way to resolve this problem in the meantime.